### PR TITLE
Add Renovate package rules for Claude Code and nsheaps actions

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -72,6 +72,16 @@
       platformAutomerge: false,
     },
     {
+      // Auto-merge all GitHub Actions updates from the nsheaps org, including
+      // digest (pinned SHA) updates. These are first-party actions we trust.
+      matchManagers: ["github-actions"],
+      matchPackageNames: ["/^nsheaps\\//"],
+      matchUpdateTypes: ["major", "minor", "patch", "digest", "pin", "pinDigest"],
+      automerge: true,
+      platformAutomerge: true,
+      automergeStrategy: "squash",
+    },
+    {
       matchManagers: ["npm"],
       // always update package.json versions, even if new versions satisfy
       // the current range(s)

--- a/default.json5
+++ b/default.json5
@@ -63,6 +63,15 @@
 
   packageRules: [
     {
+      // Never auto-merge Claude Code updates - these should always be reviewed
+      // manually. Matches both the GitHub repo slug (github-actions/github-releases
+      // datasources) and the npm package. Overrides the global automerge: true and
+      // the platformAutomerge enabled by the gha-digest-automerge preset.
+      matchPackageNames: ["anthropics/claude-code", "@anthropic-ai/claude-code"],
+      automerge: false,
+      platformAutomerge: false,
+    },
+    {
       matchManagers: ["npm"],
       // always update package.json versions, even if new versions satisfy
       // the current range(s)

--- a/default.json5
+++ b/default.json5
@@ -67,7 +67,7 @@
       // manually. Matches both the GitHub repo slug (github-actions/github-releases
       // datasources) and the npm package. Overrides the global automerge: true and
       // the platformAutomerge enabled by the gha-digest-automerge preset.
-      matchPackageNames: ["anthropics/claude-code", "@anthropic-ai/claude-code"],
+      matchPackageNames: ["anthropics/claude-code", "@anthropic-ai/claude-code", "claude-code"],
       automerge: false,
       platformAutomerge: false,
     },

--- a/default.json5
+++ b/default.json5
@@ -80,6 +80,8 @@
       automerge: true,
       platformAutomerge: true,
       automergeStrategy: "squash",
+      // First-party actions - no need to wait out the global release-age window
+      minimumReleaseAge: 0,
     },
     {
       matchManagers: ["npm"],


### PR DESCRIPTION
## Summary
Added two new Renovate package rules to the configuration to handle special cases for Claude Code updates and first-party GitHub Actions from the nsheaps organization.

## Key Changes
- **Claude Code rule**: Disables auto-merge for Claude Code updates (both GitHub and npm package sources) to ensure manual review, overriding the global automerge setting
- **nsheaps actions rule**: Enables auto-merge for all GitHub Actions from the nsheaps organization with squash strategy, treating them as trusted first-party actions with no release-age waiting period

## Implementation Details
- The Claude Code rule matches both the GitHub repository slug format and the npm package name to catch updates from all sources
- The nsheaps rule uses a regex pattern to match all packages from that organization and covers all update types including digest and pin updates
- Both rules explicitly set `platformAutomerge` to ensure consistent behavior across different merge platforms

https://claude.ai/code/session_01FtBSRuw7LG7sVfpUVVTdsW