### PR TITLE
Expand trusted GitHub Actions automerge to include squink org

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -72,14 +72,34 @@
       platformAutomerge: false,
     },
     {
-      // Auto-merge all GitHub Actions updates from the nsheaps org, including
-      // digest (pinned SHA) updates. These are first-party actions we trust.
+      // Group ALL GitHub Actions updates from the nsheaps AND squink owners
+      // (first-party / trusted) into ONE branch+merge so they create the least
+      // possible noise. Covers every update type — major, minor, patch, AND
+      // digest (pinned SHA) — intentionally overriding the broader "GitHub
+      // Actions" group from group-gha-updates.json5 for these two owners.
+      //
+      // These updates use Renovate-driven *branch* automerge
+      // (automergeType: "branch"): Renovate commits the update to a branch and,
+      // once required checks pass, merges it straight into the base branch
+      // WITHOUT opening a PR. platformAutomerge is therefore disabled — it only
+      // applies to PR-based automerge and conflicts with the "branch" type.
+      //
+      // NOTE: branch automerge to a protected `main` only takes effect once the
+      // org-wide repo-settings change in nsheaps/.github lands, granting the
+      // Renovate GitHub App a per-actor bypass of the PR/review requirement
+      // (required status checks still apply). See that PR for details.
+      //
+      // Reconciles/replaces the prior nsheaps-only auto-merge rule (PR #290).
+      // Digest pins are left intact (gha-pin-digests.json5 still applies).
       matchManagers: ["github-actions"],
-      matchPackageNames: ["/^nsheaps\\//"],
+      matchPackageNames: ["/^nsheaps\\//", "/^squink\\//"],
       matchUpdateTypes: ["major", "minor", "patch", "digest", "pin", "pinDigest"],
+      groupName: "nsheaps + squink GitHub Actions",
+      groupSlug: "nsheaps-squink-github-actions",
       automerge: true,
-      platformAutomerge: true,
+      automergeType: "branch",
       automergeStrategy: "squash",
+      platformAutomerge: false,
       // First-party actions - no need to wait out the global release-age window
       minimumReleaseAge: 0,
     },


### PR DESCRIPTION
## Summary
Extends the first-party GitHub Actions automerge rule to include both `nsheaps` and `squink` organizations, while switching from PR-based to branch-based automerge for cleaner integration with protected branches.

## Key Changes
- **Expanded scope**: Added `squink` organization to the trusted GitHub Actions automerge rule alongside `nsheaps`
- **Automerge strategy**: Changed from `platformAutomerge: true` (PR-based) to `automergeType: "branch"` (direct branch merge)
  - Branch automerge commits updates directly without opening a PR, reducing noise
  - Disabled `platformAutomerge` as it only applies to PR-based merges and conflicts with branch-type automerge
- **Grouping**: Added explicit `groupName` and `groupSlug` to consolidate all updates from both orgs into a single branch
- **Documentation**: Significantly expanded inline comments explaining:
  - The rationale for grouping both organizations together
  - How branch automerge works and why `platformAutomerge` is disabled
  - Prerequisites for branch automerge on protected `main` (org-wide repo-settings change required)
  - Reference to prior PR #290 and relationship to digest pinning rules

## Implementation Details
- Maintains coverage of all update types: major, minor, patch, digest, pin, and pinDigest
- Preserves `minimumReleaseAge: 0` for first-party actions (no release-age waiting period)
- Keeps `automergeStrategy: "squash"` for clean commit history
- Branch automerge to protected branches requires a separate org-level configuration change to grant the Renovate GitHub App a per-actor bypass of PR/review requirements

https://claude.ai/code/session_01RuJ7M2wVsKpNBZqskermWB